### PR TITLE
Add include sys

### DIFF
--- a/source/custombuild.py
+++ b/source/custombuild.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import subprocess
 import shutil
 import burger


### PR DESCRIPTION
Fixes 

```
Traceback (most recent call last):
  File "./custombuild.py", line 57, in <module>
    sys.exit(main(os.path.dirname(os.path.abspath(__file__))))
NameError: name 'sys' is not defined
```
